### PR TITLE
Cleanup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [What is ddev-vite?](#what-is-ddev-vite)
 - [Components of the repository](#components-of-the-repository)
 - [Getting started](#getting-started)
-    - [Automatically start ViteJs](#automatically-start-vitejs)
+  - [Automatically start ViteJs](#automatically-start-vitejs)
 - [How to debug tests (Github Actions)](#how-to-debug-tests-github-actions)
 
 ## What is ddev-vite?
@@ -17,8 +17,6 @@ It is based on the article [Working with Vite in DDEV - an introduction](https:/
 Developers are responsible for installing, maintaining, and running the Vite server. This add-on only exposes the port.
 
 For a full-featured Vite DDEV addon, please use the excellent [torenware/ddev-viteserve](https://github.com/torenware/ddev-viteserve) add-on.
-
-![template button](images/template-button.png)
 
 ## Components of the repository
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ This add-on is a low-config option that exposes Vite's default port from DDEV so
 It is based on the article [Working with Vite in DDEV - an introduction](https://ddev.com/blog/working-with-vite-in-ddev/), by Matthias Andrasch.
 Developers are responsible for installing, maintaining, and running the Vite server. This add-on only exposes the port.
 
-For a full-featured Vite DDEV addon, please use the excellent [torenware/ddev-viteserve](https://github.com/torenware/ddev-viteserve) add-on.
-
 ## Components of the repository
 
 - [config.vite.yaml](config.vite.yaml): configure DDEV to expose the port.


### PR DESCRIPTION
This PR cleans up the main doc page:

- Remove template image
- Remove reference to torenware/ddev-viteserve, which appears abandoned
- Remove test debug information