### PR TITLE
Cleanup README (redo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [What is ddev-vite?](#what-is-ddev-vite)
 - [Components of the repository](#components-of-the-repository)
 - [Getting started](#getting-started)
-    - [Automatically start ViteJs](#automatically-start-vitejs)
+  - [Automatically start ViteJs](#automatically-start-vitejs)
 - [How to debug tests (Github Actions)](#how-to-debug-tests-github-actions)
 
 ## What is ddev-vite?
@@ -17,8 +17,6 @@ It is based on the article [Working with Vite in DDEV - an introduction](https:/
 Developers are responsible for installing, maintaining, and running the Vite server. This add-on only exposes the port.
 
 For a full-featured Vite DDEV addon, please use the excellent [torenware/ddev-viteserve](https://github.com/torenware/ddev-viteserve) add-on.
-
-![template button](images/template-button.png)
 
 ## Components of the repository
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 - [Components of the repository](#components-of-the-repository)
 - [Getting started](#getting-started)
   - [Automatically start ViteJs](#automatically-start-vitejs)
-- [How to debug tests (Github Actions)](#how-to-debug-tests-github-actions)
 
 ## What is ddev-vite?
 
@@ -71,46 +70,5 @@ hooks:
   post-start:
     - exec: npm run dev
 ```
-
-## How to debug tests (Github Actions)
-
-1. You need an SSH-key registered with GitHub. You either pick the key you have already used with `github.com` or you create a dedicated new one with `ssh-keygen -t ed25519 -a 64 -f tmate_ed25519 -C "$(date +'%d-%m-%Y')"` and add it at `https://github.com/settings/keys`.
-
-2. Add the following snippet to `~/.ssh/config`:
-
-```
-Host *.tmate.io
-    User git
-    AddKeysToAgent yes
-    UseKeychain yes
-    PreferredAuthentications publickey
-    IdentitiesOnly yes
-    IdentityFile ~/.ssh/tmate_ed25519
-```
-
-3. Go to `https://github.com/<user>/<repo>/actions/workflows/tests.yml`.
-
-4. Click the `Run workflow` button and you will have the option to select the branch to run the workflow from and activate `tmate` by checking the `Debug with tmate` checkbox for this run.
-
-![tmate](images/gh-tmate.jpg)
-
-5. After the `workflow_dispatch` event was triggered, click the `All workflows` link in the sidebar and then click the `tests` action in progress workflow.
-
-7. Pick one of the jobs in progress in the sidebar.
-
-8. Wait until the current task list reaches the `tmate debugging session` section and the output shows something like:
-
-```
-106 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-107 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-108 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-109 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-```
-
-9. Copy and execute the first option `ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io` in the terminal and continue by pressing either <kbd>q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd>.
-
-10. Start the Bats test with `bats ./tests/test.bats`.
-
-For a more detailed documentation about `tmate` see [Debug your GitHub Actions by using tmate](https://mxschmitt.github.io/action-tmate/).
 
 **Contributed and maintained by [@tyler36](https://github.com/tyler36)**

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ This add-on is a low-config option that exposes Vite's default port from DDEV so
 It is based on the article [Working with Vite in DDEV - an introduction](https://ddev.com/blog/working-with-vite-in-ddev/), by Matthias Andrasch.
 Developers are responsible for installing, maintaining, and running the Vite server. This add-on only exposes the port.
 
-For a full-featured Vite DDEV addon, please use the excellent [torenware/ddev-viteserve](https://github.com/torenware/ddev-viteserve) add-on.
-
 ## Components of the repository
 
 - [config.vite.yaml](config.vite.yaml): configure DDEV to expose the port.


### PR DESCRIPTION
This PR cleans up the main doc page:

Remove template image
Remove reference to torenware/ddev-viteserve, which appears abandoned
Remove test debug information