### PR TITLE
docs: update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This add-on assumes the developer has:
 1. Install the add-on and restart DDEV
 
 ```shell
-ddev get tyler36/ddev-vite
+ddev add-on get tyler36/ddev-vite
 ddev restart
 ```
 


### PR DESCRIPTION
In DDEV 1.23.5 the `ddev get` command was deprecated in favor of `ddev add-on` get.

This PR updates the README to refer to comply with current best practises. 